### PR TITLE
Readme: Fix button example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,15 @@ var myVar = wrapper.removeTcVar('VarKey');
 wrapper.captureEvent(eventLabel, htmlElement, data);
 ```
 ### In JSX
+[Example onClick Method `handleAddQuantityItem`](https://github.com/TagCommander/react-tag-commander/blob/master/tag-commander-sample-app/src/components/shop/Panier.js#L14-L17).
+
 ```html
 <button 
-    className="sm-button green-500"
-    onClick={(event) => this.handle(index, event, item.name)}
+  className="sm-button green-500"
+  onClick={(event) => this.handleAddQuantityItem(index, event, item.name)}
 > + </button>
-
 ```
+
 
 ## How to reload your container
 When you update your varible you also need to update your container to propagate the changes


### PR DESCRIPTION
The example did not work. Based on the vue example https://github.com/TagCommander/vue-tag-commander/blob/master/README.md#in-template this button onClick should call the method. Which is also what happens in the example https://github.com/TagCommander/react-tag-commander/blob/master/tag-commander-sample-app/src/components/shop/PageItem.js#L63-L66.

To make the readme more usable, I also added a link to the onClick method definition from the example.