### PR TITLE
Add container fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export default class TC_Wrapper {
           if(containers[i].id === id) {
             let node = containers[i].node.toLowerCase();
             let parent = document.getElementsByTagName(node)[0];
-            if (parent && container && parent.includes(container)) {
+            if (parent && container && container.parentNode === parent) {
                 parent.removeChild(container);
             }
             this.tcContainers.splice(i, 1);

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,10 @@ export default class TC_Wrapper {
         for(let i = 0; i < containers.length; i++) {
           if(containers[i].id === id) {
             let node = containers[i].node.toLowerCase();
-            document.getElementsByTagName(node)[0].removeChild(container);
+            let parent = document.getElementsByTagName(node)[0];
+            if (parent && container && parent.includes(container)) {
+                parent.removeChild(container);
+            }
             this.tcContainers.splice(i, 1);
           }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export default class TC_Wrapper {
             node: updatedNode
         });
 
-        window.document.getElementsByTagName(node.toLowerCase())[0].appendChild(tagContainer);
+        window.document.getElementsByTagName(updatedNode.toLowerCase())[0].appendChild(tagContainer);
     };
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -38,22 +38,24 @@ export default class TC_Wrapper {
             this.logger.warn('The container uri should be a string.');
         }
 
-        this.tcContainers.push({
-            id: id,
-            uri: uri
-        });
-
         let tagContainer = document.createElement('script');
         tagContainer.setAttribute('type', 'text/javascript');
         tagContainer.setAttribute('src', uri);
         tagContainer.setAttribute('id', id);
+        let updatedNode = node;
         
         if(!node || typeof node !== 'string'
             || typeof window.document.getElementsByTagName(node.toLowerCase())[0] === 'undefined') {
 
             this.logger.warn('The script will be placed in the head by default.');
-            return window.document.getElementsByTagName('head')[0].appendChild(tagContainer);
+            updatedNode = 'head';
         }
+
+        this.tcContainers.push({
+            id: id,
+            uri: uri,
+            node: updatedNode
+        });
 
         window.document.getElementsByTagName(node.toLowerCase())[0].appendChild(tagContainer);
     };
@@ -66,10 +68,10 @@ export default class TC_Wrapper {
         let container = document.getElementById(id);
         let containers = this.tcContainers.slice(0);
     
-        document.getElementsByTagName('head')[0].removeChild(container);
-    
         for(let i = 0; i < containers.length; i++) {
           if(containers[i].id === id) {
+            let node = containers[i].node.toLowerCase();
+            document.getElementsByTagName(node)[0].removeChild(container);
             this.tcContainers.splice(i, 1);
           }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export default class TC_Wrapper {
         tagContainer.setAttribute('src', uri);
         tagContainer.setAttribute('id', id);
         
-        if(!node || typeof node !== 'string' || node.toLowerCase() === 'head' || node.toLowerCase() === "body"
+        if(!node || typeof node !== 'string'
             || typeof window.document.getElementsByTagName(node.toLowerCase())[0] === 'undefined') {
 
             this.logger.warn('The script will be placed in the head by default.');


### PR DESCRIPTION
- removed the checks `node.toLowerCase() === 'head' || node.toLowerCase() === "body"` from the condition that raises a warning and adds to the head as a fallback
- `removeContainer` is only removing containers from the head, so I added the node to the properties of the containers in the `tcContainers` array, and this allows us to remove a container from its actual parent
- in order to have the correct nodes in the `tcContainers` array I had to re-arrange the code in `addContainer`
- added a check that both parent and container exist and that parent contains the container in order to manage some edge cases with Hot Module Replacement in Gatsby
- should close the issue: https://github.com/TagCommander/react-tag-commander/issues/5